### PR TITLE
Update to XWiki 8.4.1 with many improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:jessie-backports
 
 MAINTAINER Fabio Mancinelli fabio.mancinelli@xwiki.com
 
@@ -6,8 +6,9 @@ MAINTAINER Fabio Mancinelli fabio.mancinelli@xwiki.com
 VOLUME ["/var/lib/mysql", "/var/lib/xwiki"]
 
 # Install JDK + MySQL + Tomcat7 + XWiki
-RUN (apt-get update && \
-     apt-get install -y openjdk-7-jdk && \
+RUN ( \
+     apt-get update && \
+     apt-get install -y openjdk-8-jdk && \
      apt-get install -y tomcat7 && \
      echo "mysql-server mysql-server/root_password password your_password" | /usr/bin/debconf-set-selections && \
      echo "mysql-server mysql-server/root_password_again password your_password" | /usr/bin/debconf-set-selections && \
@@ -18,6 +19,7 @@ RUN (apt-get update && \
      unzip -d /var/lib/tomcat7/webapps/xwiki /tmp/xwiki-enterprise-web-8.4.1.war && \
      wget -P /var/lib/tomcat7/webapps/xwiki/WEB-INF/lib http://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.35/mysql-connector-java-5.1.35.jar && \
      mkdir -p /var/lib/xwiki && \
+     mkdir -p /var/tmp/xwiki && \
      chown tomcat7:tomcat7 /var/lib/xwiki && \
      mkdir -p /var/lib/tomcat7/bin && \
      chown tomcat7:tomcat7 /var/lib/tomcat7/bin && \
@@ -32,5 +34,4 @@ CMD ["/start_xwiki.sh"]
 
 # Expose port
 EXPOSE 8080
-
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN ( \
      cd xinit && \
      ./install.sh --install && \
      chown -R tomcat7:tomcat7 /var/lib/xwiki && \
+     sed "s/<id>org.xwiki.enterprise:xwiki-enterprise-web/<id>org.xwiki.enterprise:xwiki-enterprise-docker/" < /var/lib/tomcat7/webapps/xwiki/META-INF/extension.xed > /var/lib/tomcat7/webapps/xwiki/META-INF/extension2.xed && \
+     mv /var/lib/tomcat7/webapps/xwiki/META-INF/extension2.xed /var/lib/tomcat7/webapps/xwiki/META-INF/extension.xed && \
      apt-get clean)
 
 # Inject configuration files

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,23 +10,25 @@ RUN ( \
      apt-get update && \
      apt-get install -y openjdk-8-jdk && \
      apt-get install -y tomcat7 && \
+     apt-get install -y libreoffice && \
      echo "mysql-server mysql-server/root_password password your_password" | /usr/bin/debconf-set-selections && \
      echo "mysql-server mysql-server/root_password_again password your_password" | /usr/bin/debconf-set-selections && \
-     apt-get install -y mysql-server && \
-     apt-get install -y wget && \
-     apt-get install -y unzip && \
+     apt-get install -y mysql-server wget unzip git vim && \
+     apt-get install -y coreutils sysvinit-utils procps sendxmpp bsd-mailx curl net-tools && \
      wget -P /tmp http://download.forge.ow2.org/xwiki/xwiki-enterprise-web-8.4.1.war && \
      unzip -d /var/lib/tomcat7/webapps/xwiki /tmp/xwiki-enterprise-web-8.4.1.war && \
      wget -P /var/lib/tomcat7/webapps/xwiki/WEB-INF/lib http://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.35/mysql-connector-java-5.1.35.jar && \
      mkdir -p /var/lib/xwiki && \
-     mkdir -p /var/tmp/xwiki && \
-     chown tomcat7:tomcat7 /var/lib/xwiki && \
-     mkdir -p /var/lib/tomcat7/bin && \
-     chown tomcat7:tomcat7 /var/lib/tomcat7/bin && \
+     git clone https://github.com/xwiki-contrib/xinit.git && \
+     cd xinit && \
+     ./install.sh --install && \
+     chown -R tomcat7:tomcat7 /var/lib/xwiki && \
      apt-get clean)
 
 # Inject configuration files
 ADD ["files/hibernate.cfg.xml", "files/xwiki.properties", "/var/lib/tomcat7/webapps/xwiki/WEB-INF/"]
+ADD ["files/xinit.cfg", "/etc/xinit/"]
+ADD ["files/index.html", "/var/lib/tomcat7/webapps/ROOT/"]
 ADD ["files/start_xwiki.sh", "/"]
 
 # Define the startup command

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN (apt-get update && \
      apt-get install -y mysql-server && \
      apt-get install -y wget && \
      apt-get install -y unzip && \
-     wget -P /tmp http://download.forge.ow2.org/xwiki/xwiki-enterprise-web-7.0.war && \
-     unzip -d /var/lib/tomcat7/webapps/xwiki /tmp/xwiki-enterprise-web-7.0.war && \
+     wget -P /tmp http://download.forge.ow2.org/xwiki/xwiki-enterprise-web-8.4.1.war && \
+     unzip -d /var/lib/tomcat7/webapps/xwiki /tmp/xwiki-enterprise-web-8.4.1.war && \
      wget -P /var/lib/tomcat7/webapps/xwiki/WEB-INF/lib http://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.35/mysql-connector-java-5.1.35.jar && \
      mkdir -p /var/lib/xwiki && \
      chown tomcat7:tomcat7 /var/lib/xwiki && \

--- a/README.md
+++ b/README.md
@@ -4,31 +4,29 @@ This project contains the Dockerfile for building a container running XWiki 7.0 
 
 # Building
 
-Just run `docker build .` and you should have your image ready in your docker repository.
+Just run `docker build -t xwiki .` and you should have your image ready in your docker repository.
 
-# Running
+# Automatic Running
 
-When running the container you must specify the following information:
+Launch quickRun.sh
 
-* Where to mount `/var/lib/mysql` for database stored data.
-* Where to mount `/var/lib/xwiki` for XWiki permament data.
-* Where to map port 8080.
+Once the container is started, you can open a browser and connect to `http://localhost:8080/xwiki`
 
-Not specifying mount points will make data stored in the wiki disappear when the container is stopped.
+# Manual Running
 
+When running the container you first need to create a data container and then stop it
+
+docker run -it -d --name xwiki-data xwiki
+docker stop xwiki-data
+
+And then run the container specifying the data container for volumes
+
+docker run --volumes-from xwiki-data -p 8080:8080 xwiki
+
+Running without a data container will make the data stored in the wiki dissapear when the container is stopped.
 Not specifying the port mapping will make XWiki inaccessible from the host.
 
-Here it is the command line to use for starting the XWiki container:
-
-    docker run -v HOST_DIR_FOR_XWIKI_DATA:/var/lib/xwiki -v HOST_DIR_FOR_MYSQL_DATA:/var/lib/mysql -p HOST_PORT_FOR_ACCESSING_XWIKI:8080 CONTAINER_ID
-
-Once the container is started, you can open a browser and connect to `http://host:HOST_PORT_FOR_ACCESSING_XWIKI/xwiki`
-
-## Making data dir accessible
-
-In order to make `HOST_DIR_FOR_XWIKI_DATA` and `HOST_DIR_FOR_MYSQL_DATA` accessible by the container, they must be executable and writable by the `tomcat7` (`UID 101`, `GID 102`) and `mysql` (`UID 103`, `GID 104`) container users - which might not exist in your host.
-
-In order to avoid writing problems do a `chown 101:103` on `HOST_DIR_FOR_XWIKI_DATA`, and `chown 102:104` on `HOST_DIR_FOR_MYSQL_DATA`.
+Once the container is started, you can open a browser and connect to `http://localhost:8080/xwiki`
 
 # Disclaimer
 

--- a/files/index.html
+++ b/files/index.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script>
+location = '/xwiki/';
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/files/start_xwiki.sh
+++ b/files/start_xwiki.sh
@@ -10,10 +10,5 @@ if ! mysql -u root -e "show databases" | grep xwiki; then
   mysql -u root -e "grant all privileges on *.* to xwiki@localhost identified by 'xwiki'"
 fi
 
-export CATALINA_HOME=/usr/share/tomcat7
-export CATALINA_BASE=/var/lib/tomcat7
-export CATALINA_OPTS="-Xmx800m -XX:MaxPermSize=192m -Djava.io.tmpdir=/var/tmp/xwiki"
-
-$CATALINA_HOME/bin/catalina.sh run
-
-
+/etc/init.d/xwiki.sh start
+bash

--- a/files/start_xwiki.sh
+++ b/files/start_xwiki.sh
@@ -12,7 +12,7 @@ fi
 
 export CATALINA_HOME=/usr/share/tomcat7
 export CATALINA_BASE=/var/lib/tomcat7
-export CATALINA_OPTS="-Xmx800m -XX:MaxPermSize=192m"
+export CATALINA_OPTS="-Xmx800m -XX:MaxPermSize=192m -Djava.io.tmpdir=/var/tmp/xwiki"
 
 $CATALINA_HOME/bin/catalina.sh run
 

--- a/files/xinit.cfg
+++ b/files/xinit.cfg
@@ -1,0 +1,294 @@
+#
+# This file it is used for JVM and tomcat.sh settings
+#
+
+####################
+# General Settings #
+####################
+
+# Jabber Notification
+#
+# SEND_JABBER_MESSAGE: If you want to send notification on jabber 
+# set this parameter to "yes". By default jabber notification is disabled.
+#SEND_JABBER_MESSAGE="no"
+
+# JABBER_USERS: Specify to what users to notify o jabber. You can choose
+# any user from LDAP Server. You can specify more then one user separating them
+# with space. Users should use the following format: user@jabber_server
+#JABBER_USERS=""
+
+# Mail Notification
+#
+# SEND_MAIL_NOTIFICATION: Set this parameter to "no" if you want to not send mail notifications.
+# By default this feature is enabled.
+#SEND_MAIL_NOTIFICATION="yes"
+
+# MAIL: Using this parameter you can specify one or more email
+# addresses to which notifications will be sent. You can specify multiple email addresses
+# by separating them with a comma (not space). 
+# Default value: empty
+#MAIL=""
+
+# SERVER_NAME: Use this parameter to set server name.
+# If this parameter is not set the output of hostname command
+# will be used.
+# Default value: empty
+#SERVER_NAME=""
+
+# LOG_LINE_NUMBER: How many lines from cataline.out file you want to 
+# include in mail notification. By default the last 2000 lines will be 
+# included in mail notification.
+#LOG_LINE_NUMBER="2000"
+
+# CONNECTION_STATE_PORTS: You can use this parameter to specify the TCP ports
+# for which you want to receive connection state information(ESTABLISHED, 
+# CLOSE_WAIT, CLOSE_WAIT ... etc). You can specify multiple ports separating
+# them with space. The default value for this parameter is "8080 8009"
+#CONNECTION_STATE_PORTS="8080 8009"
+
+# LANG: Using this parameter you can set the locale name.
+# By default it is set to "en_US.UTF-8"
+#LANG="en_US.UTF-8"
+
+# MYSQL_USER: Use this parameter to set a user which will be used to
+# access mysql server. User must have privileges to list the full
+# process list table and all databases.
+# Default value: "root"
+#MYSQL_USER="root"
+
+# MYSQL_PASSWORD: Password to use when connecting to mysql server.
+# Default value: empty
+#MYSQL_PASSWORD=""
+
+# MYSQL_HOST: Use this parameter to specify a host other then localhost.
+# This host will be used to get mysql statistics and informations.
+# Default value: "localhost"
+#MYSQL_HOST="localhost"
+
+# SPAM_THRESHOLD: This parameter is use to set a threshold for spam detection.
+# All pages with an amount of comments >= this parameter will be considered as spammed.
+#SPAM_THRESHOLD="50"
+
+# DAEMONS_TO_MONITOR: Use this parameter to specify for which daemons
+# you want to receive top informations. Separate them with space.
+# Default value: "java mysqld apache2" 
+#DAEMONS_TO_MONITOR="java mysqld apache2"
+
+# XWIKI_INSTALL_DIR: Use this parameter to specify the path where XWiki
+# is installed.
+# Default value: "usr/local/xwiki"
+#XWIKI_INSTALL_DIR="/usr/local/xwiki"
+
+# VAR_DIR: Specifies where to store temporary data needed by the program
+# Default value: "/var/run/xinit"
+#VAR_DIR="/var/run/xinit"
+
+# KILL_QUIT_TIME_WAIT: Use this parameter to set how much time (in seconds)
+# to wait after kill -QUIT command is executed.
+# Default value: 4
+#KILL_QUIT_TIME_WAIT="4"
+
+# MAINTENANCE_ON_RESTARTS : Enable maintenance mode on any restart, including crashes.
+# It will create $VAR_DIR/maintenance file (default /var/run/xinit/maintenance) if set to 1, during restarts.
+# Default value: 1
+#MAINTENANCE_ON_RESTARTS="1"
+
+# MAINTENANCE_TIME : Parameter to set a maintenance time set after any restart
+# that can occur. The wiki won't be restarted again during that amount of seconds.
+# Default value: 600
+#MAINTENANCE_TIME="600"
+
+# MAINTENANCE_REMINDER : Send an email periodically to the emails in the MAIL parameter while maintenance mode is on
+# You can change the interval at which the emails are sent using the MAINTENANCE_REMINDER_PERIOD variable below.
+# Default value: 1
+#MAINTENANCE_REMINDER="1"
+
+# MAINTENANCE_REMINDER_PERIOD : Sets the period in which maintenance reminder emails are being sent. Only useful if
+# MAITENANCE_REMINDER is enabled
+# Default value: 3600
+#MAINTENANCE_REMINDER_PERIOD="3600"
+
+# CLEAN_TEMP_ON_STARTUP : Enable this if you want to remove everything in the Tomcat temp folder when starting up
+# Default value: 1
+#CLEAN_TEMP_ON_STARTUP="1"
+
+# THREADDUMP_ANALYSIS_FILE : If THREADDUMP_ANALYSIS is enabled below, this file will store the
+# Thread dump data sent to the webservice
+# Default value: /var/tmp/xinit_thread_dump
+#THREADDUMP_ANALYSIS_FILE="/var/tmp/xinit_thread_dump"
+
+# THREADDUMP_ANALYSIS : Send the thread dump to a remote webservice for analysis and return the
+# results inside the report. Set to empty if you want this feature disabled.
+# Example value: "curl --data-binary @$THREADDUMP_ANALYSIS_FILE http://jthreader.xwiki.com/api/1/explain"
+# Above example uses the XWikiSAS provided jthreader web serivce.
+# Default value: ""
+#THREADDUMP_ANALYSIS=""
+
+
+#################
+# First Request	#
+#################
+#
+# MAKE_FIRST_REQUEST: After Tomcat is started you can choose to make
+# the first request by setting this patrameter to "yes". HTTP Check will
+# be used to make the first request.
+# By default the first request is disabled.
+#MAKE_FIRST_REQUEST="no"
+
+####################
+# OpenOffice Check #
+####################
+
+# OO_CHECK: Set this parameter to 1 if you want to check
+# OpenOffice status or 0 instead. By default it is set to 1.
+OO_CHECK="0"
+
+# OO_SERVER_TYPE: This parameter takes a value of 0 or 1
+# 0 - Internally managed server instance. (Default)
+# 1 - Externally managed (local) server instance.
+# When OO server is internally managed it will only be checked
+# when tomcat is stopped/restarted and it will be killed if it is
+# still running after tomcat is stopped.
+#OO_SERVER_TYPE="0"
+
+# OO_SERVER_PORT: This parameter specify on which port should
+# OpenOffice daemon run. Default is 8100
+#OO_SERVER_PORT="8100"
+
+# OO_DAEMON_PATH: This parameter specifies the path to OO daemon.
+# Default is: /opt/openoffice.org3/program/soffice.bin
+#OO_DAEMON_PATH="/opt/openoffice.org3/program/soffice.bin"
+
+##############
+# HTTP Check #
+##############
+
+# CHECK_HTTP: This parameter is used to enable/disable http check function.
+# Set this parameter to "yes" is you want to enable http check function.
+# By default http check function is disabled.
+#CHECK_HTTP="no"
+
+# EXPECT_HTTP_RESPONSE_CODE: Use this parameter to specify a http respons code. This
+# code is used to determine if the wiki is available or not. Some useful http codes are:
+# 200 OK
+# 400 Bad Request 
+# 401 Unauthorized
+# 403 Forbidden
+# 404 Not Found
+# 405 Method Not Allowed
+# 500 Internal Server Error
+# Typically any of these codes may means that the wiki is responding. For example if
+# xinit is trying to access a page that for which it need to login to the wiki it will
+# receive an 401 code. But that means it was able to access that page in an amount of time
+# and it can say that the wiki is available. Xinit will receive code 200 when the page is
+# trying to access is public.
+# You can use any of the HTTP/1.1 response code protocol.
+# Default value: 200
+#EXPECT_HTTP_RESPONSE_CODE="200"
+
+# USE_DNS: This parameter is used to specify if xinit will take into account if the 
+# domain name used to check the wiki was resolve or not. If set to "yes" xinit will NOT
+# restart the wiki in case it was not able to resolve the domain name but a mail will be sent
+# to the addresses specified by MAIL parameter. Set this parameter to "no" in case you
+# don't want enable this feature.
+# Default value: yes
+#USE_DNS="yes"
+
+# CHECK_HTTP_URL: Use this parameter to pecify the address of the wiki you want to check.
+# You can use an IP or a domain name and you can also specify a different port to connect to.
+# The format is: http://domain or http://domain:8080 or use and IP.
+# If ca use https instead of http.
+# Default value: empty
+#CHECK_HTTP_URL=""
+
+# USE_BASIC_AUTH: Set this parameter to "yes" if you want to enable basic authentication.
+# Default value: "no"
+#USE_BASIC_AUTH="no"
+
+# These parameters are used in case the wiki is protected
+# with an htaccess file. In this case a username and password
+# are needed to check the wiki availability.
+#HTACCESS_USERNAME="username"
+#HTACCESS_PASSWORD="password"
+
+# Http time parameters in sec.
+#CHECK_HTTP_TIMEOUT="50"
+#CHECK_HTTP_TRIES="2"
+#CHECK_HTTP_WAITRETRY="10"
+
+#################
+# Profiling     #
+#################
+
+# JVM_AGENTPATH: Unset by default
+# Ex for Yourkit on a X64 linux:
+# JVM_AGENTPATH="/usr/local/yjp/bin/linux-x86-64/libyjpagent.so=delay=10000,sessionname=XWiki"
+
+#################
+# Process Check #
+#################
+
+# This function checks if the java process is running or not.
+
+# PROCESS_CHECK: This function is enabled by default
+# and can be disabled by setting this parameter to "no".
+#PROCESS_CHECK="yes"
+
+# JVM & Apache Tomcat Settings
+#
+# NAME: Default value: "Tomcat"
+#NAME="Tomcat"
+
+# TOMCAT_HOME: Default value "/usr/local/tomcat"
+TOMCAT_HOME="/usr/share/tomcat7"
+
+# Special conf
+CATALINA_BASE="/var/lib/tomcat7"
+CATALINA_HOME="/usr/share/tomcat7"
+export CATALINA_BASE
+export CATALINA_HOME
+
+# JAVA_HOME: Defult value "/usr/local/java"
+JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+
+# CATALINA_PID: Default value "/var/tmp/catalina.pid"
+#CATALINA_PID="/var/tmp/catalina.pid"
+
+# MEM_START: minimum heap size (-Xms)
+# If you change the default value you MUST uncomment
+# CATALINA_OPTS parameter.
+# Default value: "128m"
+#MEM_START="128m"
+
+# MEM_MAX: maximum heap size (-Xmx)
+# If you change the default value you MUST uncomment
+# CATALINA_OPTS parameter.
+# Default value: "512m"
+#MEM_MAX="512m"
+
+# MAX_PERM_SIZE: this argument adjusts the size of the "permanent generation."
+# The perm gen holds information about the "stuff" in the heap.  
+# So, the heap stores the objects and the perm gen keeps information about the 
+# "stuff" inside of it.  Consequently, the larger the heap, 
+# the larger the perm gen needs to be.
+# If you change the default value you MUST uncomment
+# CATALINA_OPTS parameter.
+# Default value: "192m"
+#MAX_PERM_SIZE="192m"
+
+# TOMCAT_USER: user java will run as.
+# Default value: "tomcat"
+TOMCAT_USER="root"
+
+# CATALINA_OPTS: cataline options
+# Default value "-server -Xms$MEM_START -Xmx$MEM_MAX -XX:MaxPermSize=$MAX_PERM_SIZE -Dfile.encoding=utf-8 -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -XX:+UseParallelGC -XX:MaxGCPauseMillis=100"
+CATALINA_OPTS="-server -Xms$MEM_START -Xmx$MEM_MAX -XX:MaxPermSize=$MAX_PERM_SIZE -Dfile.encoding=utf-8 -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -XX:+UseParallelGC -XX:MaxGCPauseMillis=100 -Dxwiki.data.dir=/var/lib/xwiki"
+
+# JVM_DEBUG: If set to "yes" tomcat will start in debug mode
+# with remote access available. 
+# Default is "no".
+#JVM_DEBUG="no"
+
+# JVM_DEBUG_OPTS: Java options to start in debug mode.
+# Default value "-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005" 
+#JVM_DEBUG_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"

--- a/files/xwiki.properties
+++ b/files/xwiki.properties
@@ -55,6 +55,15 @@
 #-# Default value is 100.
 # core.renderingcache.size=100
 
+#-# [Since 7.2M2]
+#-# Define which hierarchy is used between pages (for example inside the breadcrumb).
+#-# Possible values are "reference" (default) or "parentchild".
+#-# If "parentchild" is used, the hierachy is based on the parent/child relationship, which means that any document
+#-# could be defined as the parent of an other document.
+#-# If "reference" is used, then the children of a document must be placed inside this document. It's less flexible but
+#-# more clear.
+# core.hierarchyMode=reference
+
 #-------------------------------------------------------------------------------------
 # Environment
 #-------------------------------------------------------------------------------------
@@ -75,7 +84,7 @@
 #-# If neither the system property nor this configuration value here are set then the Servlet container's temporary
 #-# directory is used; This is absolutely not recommended since that directory could be wiped out at any time and you
 #-# should specify a value.
-environment.permanentDirectory=/var/lib/xwiki
+environment.permanentDirectory=/var/local/xwiki/
 
 #-------------------------------------------------------------------------------------
 # Rendering
@@ -85,16 +94,21 @@ environment.permanentDirectory=/var/lib/xwiki
 #-# Specifies how links labels are displayed when the user doesn't specify the label explicitly.
 #-# Valid values:
 #-#   %w: wiki name
-#-#   %s: space name
+#-#   %s: full space name (e.g. space1.space2)
+#-#       Note: Prior to 7.4.2/8.0M2 this was only displaying the last space name
+#-#   %ls: last space name. New in 7.4.2/8.0M2
 #-#   %p: page name
+#-#   %np: nested page name (i.e. will display the space name for Nested Pages). New in 7.4.2/8.0M2
 #-#   %P: page name with spaces between camel case words, i.e. "My Page" if the page name is "MyPage"
+#-#   %NP: nested page name with spaces between camel case words, i.e. "My Page" if the page name is "MyPage".
+#-#        New in 7.4.2/8.0M2
 #-#   %t: page title
 #-#
-#-# Note that if the page title is empty or not defined then it defaults to %p. This is also the case
+#-# Note that if the page title is empty or not defined then it defaults to %np. This is also the case
 #-# if the title cannot be retrieved for the document.
 #-#
-#-# The default is "%p". Some examples: "%s.%p", "%w:%s.%p".
-# rendering.linkLabelFormat = %p
+#-# The default is "%np". Some examples: "%s.%p", "%w:%s.%p".
+# rendering.linkLabelFormat = %np
 
 #-# [Since 2.0M3]
 #-# Overrides default macro categories (Each macro has a default category already defined, for example
@@ -290,8 +304,7 @@ environment.permanentDirectory=/var/lib/xwiki
 #-#   velocity.properties = velocimacro.messages.on = false
 #-#   velocity.properties = resource.manager.logwhenfound = false
 #-#   velocity.properties = velocimacro.permissions.allow.inline.local.scope = true
-#-#   velocity.properties = runtime.introspector.uberspect = org.xwiki.velocity.introspection.ChainingUberspector
-#-#   velocity.properties = runtime.introspector.uberspect.chainClasses = org.xwiki.velocity.introspection.SecureUberspector\,org.xwiki.velocity.introspection.DeprecatedCheckUberspector\,org.xwiki.velocity.introspection.MethodArgumentsUberspector
+#-#   velocity.properties = runtime.introspector.uberspect = org.xwiki.velocity.introspection.SecureUberspector\,org.xwiki.velocity.introspection.DeprecatedCheckUberspector\,org.xwiki.velocity.introspection.MethodArgumentsUberspector
 
 #-------------------------------------------------------------------------------------
 # Groovy
@@ -336,79 +349,6 @@ environment.permanentDirectory=/var/lib/xwiki
 #-# Example: observation.remote.networkadapter = jgroups
 
 #-------------------------------------------------------------------------------------
-# Cryptographic services
-#-------------------------------------------------------------------------------------
-
-#-# [Since 2.5M1]
-#-# Which cipher should be used for encrypting text with a password.
-#-#
-#-# Options are:
-#-# CAST5PasswordCiphertext (Uses CAST-5 cipher engine with a 128 bit key)
-#-# AESPasswordCiphertext (Uses AES cipher engine with a 128 bit key)
-#-#
-#-# NOTE: Encrypted text can still be decrypted even if the cipher or key function has changed.
-#-#
-#crypto.passwd.passwordCiphertext = CAST5PasswordCiphertext
-
-#-# [Since 2.5M1]
-#-# Which key derivation function to use.
-#-# Since the easiest attack on password encrypted text is to guess passwords, this function ensures that verification
-#-# of a password takes a long time for the computer and is inherently difficult to parallelize.
-#-#
-#-# Options are:
-#-# ScryptMemoryHardKeyDerivationFunction (Uses the scrypt key function which forces password guessers to expend a
-#-#                                        a configurable amount of processor time and memory to validate guesses
-#-#                                        Scrypt is conjectured to be 260 times the strength of PBKDF2
-#-#                                        Function definition available here: http://www.tarsnap.com/scrypt.html)
-#-# PBKDF2KeyDerivationFunction (Uses password based key derivation function 2 (PBKDF2) developed by RSA labs as part
-#-#                              of the PKCS#5 standard. This function uses a configurable amount of processor time
-#-#                              but an insignificant amount of memory.
-#-#                              Function definition available here: http://www.apps.ietf.org/rfc/rfc2898.html#sec-5.2)
-#-#
-#crypto.passwd.keyDerivationFunctionClassForEncryption = ScryptMemoryHardKeyDerivationFunction
-
-#-# [Since 2.5M1]
-#-# Define the properties for initializing the dey derivation functions for encryption.
-#-#
-#-# millisecondsOfProcessorTimeToSpend is used to test run the key function and decide how many iterations it should
-#-#                                    use. Remember this amount of time will be required to convert the password to
-#-#                                    the decryption key every time the text needs to be decrypted.
-#-# numberOfKilobytesOfMemoryToUse will be ignored unless a memory hard function such as scrypt is chosen in which
-#-#                                case it will be used to define how much memory should be required to derive the
-#-#                                decryption key from the password.
-#-#
-#-# CAUTION: If numberOfKilobytesOfMemoryToUse is set too large, the computer may be able to encrypt a piece of text
-#-#          when it has lots of free memory available, then be unable to decrypt that text when less memory is
-#-#          available. Unless you are very paranoid, 1 megabyte (1024) is plenty of strength.
-#-#
-#crypto.passwd.keyDerivationFunctionPropertiesForEncryption = millisecondsOfProcessorTimeToSpend = 200
-#crypto.passwd.keyDerivationFunctionPropertiesForEncryption = numberOfKilobytesOfMemoryToUse = 1024
-
-#-# [Since 2.5M1]
-#-# Which key derivation function to use for protecting (hashing) passwords.
-#-# Options include:
-#-# ScryptMemoryHardKeyDerivationFunction (See above for more information)
-#-# PBKDF2KeyDerivationFunction (See above for more information)
-#-#
-#crypto.passwd.keyDerivationFunctionClassForPasswordVerification = ScryptMemoryHardKeyDerivationFunction
-
-#-# [Since 2.5M1]
-#-# Properties to use when initializing key derivation functions for password protection.
-#-#
-#-# millisecondsOfProcessorTimeToSpend (See above for description.)
-#-# numberOfKilobytesOfMemoryToUse (See above for description.)
-#-# derivedKeyLength is the number of bytes of length which the output key should be. In a password verification
-#-#                  context, this is only valid for decreasing the chance of a collision.
-#-#
-#-# CAUTION: If numberOfKilobytesOfMemoryToUse is set too large, the computer may be able to protect a password
-#-#          when it has lots of free memory available, then be unable to validate that password when less memory is
-#-#          available. Unless you are very paranoid, 1 megabyte (1024) is plenty of strength.
-#-#
-#crypto.passwd.keyDerivationFunctionPropertiesForPasswordVerification = millisecondsOfProcessorTimeToSpend = 200
-#crypto.passwd.keyDerivationFunctionPropertiesForPasswordVerification = numberOfKilobytesOfMemoryToUse = 1024
-#crypto.passwd.keyDerivationFunctionPropertiesForPasswordVerification = derivedKeyLength = 32
-
-#-------------------------------------------------------------------------------------
 # CSRF token component
 #-------------------------------------------------------------------------------------
 
@@ -427,11 +367,26 @@ environment.permanentDirectory=/var/lib/xwiki
 # csrf.enabled = true
 
 #-------------------------------------------------------------------------------------
+# Jobs
+#-------------------------------------------------------------------------------------
+
+#-# [Since 4.0M1]
+#-# The folder containing job executing status.
+#-# The default is {environment.permanentDirectory}/jobs/
+# job.statusFolder=/var/lib/xwiki/data/jobs/
+
+#-# [Since 7.2M2]
+#-# The maximum number of entries to put in the job status cache.
+#-# The default is 50.
+# job.statusCacheSize=50
+
+#-------------------------------------------------------------------------------------
 # Extension Manager
 #-------------------------------------------------------------------------------------
 
 #-# [Since 2.5]
 #-# Repositories to use when searching and downloading extensions.
+#-# Repositories will be checked in the same order they have in this configuration file.
 #-# 
 #-# The format is <id>:<type>:<url> where
 #-# * id can be anything as long as there is only one
@@ -449,14 +404,16 @@ environment.permanentDirectory=/var/lib/xwiki
 # extension.repositories.privatemavenid.auth.password=thepassword
 #-# 
 #-# Here's an example to add your local Maven Repository
-# extension.repositories=local:maven:file://${sys:user.home}/.m2/repository
+# extension.repositories=maven-local:maven:file://${sys:user.home}/.m2/repository
 #-#
 #-# And an example to add the XWiki Maven Snapshot Repository
 # extension.repositories=maven-xwiki-snapshot:maven:http://nexus.xwiki.org/nexus/content/groups/public-snapshots
 #-#
-#-# When not set the following is taken:
-# extension.repositories=maven-xwiki:maven:http://nexus.xwiki.org/nexus/content/groups/public
-# extension.repositories=extensions.xwiki.org:xwiki:http://extensions.xwiki.org/xwiki/rest/
+#-# When not set the following is taken (in this order):
+extension.repositories=maven-xwiki:maven:http://nexus.xwiki.org/nexus/content/groups/public
+extension.repositories=store.xwiki.com:xwiki:https://store.xwiki.com/xwiki/rest/
+extension.repositories=store.devxwiki.com:xwiki:https://store.devxwiki.com/xwiki/rest/
+extension.repositories=extensions.xwiki.org:xwiki:http://extensions.xwiki.org/xwiki/rest/
 #-# 
 #-# To not have any repository enabled (including disabling default repositories) you can explicitly make this list empty:
 # extension.repositories=
@@ -473,6 +430,32 @@ environment.permanentDirectory=/var/lib/xwiki
 #-# 
 #-# The default is:
 # extension.userAgent=XWikiExtensionManager
+
+#-# [Since 7.1RC1]
+#-# Some extensions considered now as flavor but released before the category exists
+#-#
+extension.oldflavors=org.xwiki.enterprise:xwiki-enterprise-ui-mainwiki
+extension.oldflavors=org.xwiki.enterprise:xwiki-enterprise-ui-wiki
+extension.oldflavors=org.xwiki.manager:xwiki-enterprise-ui
+extension.oldflavors=org.xwiki.manager:xwiki-manager-wiki-administrator
+extension.oldflavors=org.xwiki.manager:xwiki-enterprise-manager-wiki-administrator
+extension.oldflavors=com.xpn.xwiki.products:xwiki-enterprise-manager-wiki-administrator
+
+#-# [Since 8.3]
+#-# Indicate of the XWiki you try to find more informations about the core extension in the repositories.
+#-# 
+#-# The default is:
+# extension.core.resolve=true
+
+#-------------------------------------------------------------------------------------
+# Distribution Wizard
+#-------------------------------------------------------------------------------------
+
+#-# [Since 7.1RC1] Enable or disable the automatic start of Distribution Wizard on empty/outdated wiki.
+#-#
+#-# The default is:
+# distribution.automaticStartOnMainWiki=true
+# distribution.automaticStartOnWiki=true
 
 #-------------------------------------------------------------------------------------
 # Solr Search
@@ -571,10 +554,10 @@ environment.permanentDirectory=/var/lib/xwiki
 #-# Defines the URL path prefix used for Entity URLs, i.e. URLs pointing to a Document, Space, Object, etc.
 #-# For example this is the "bin" part in the following URL:
 #-#   http://server/xwiki/bin/view/space/page
-#-# Note that this replaces the old xwiki.defaultservletpath property in the old xwiki.cfg file.
+#-# Note that this replaces the old xwiki.defaultservletpath property in the xwiki.cfg file.
 #-#
 #-# The default is:
-# url.standard.getEntityPathPrefix=bin
+# url.standard.entityPathPrefix=bin
 
 #-# [Since 5.3M1]
 #-# The action to take when a subwiki is not found (ie there's no wiki descriptor for it). Valid values are:
@@ -583,6 +566,13 @@ environment.permanentDirectory=/var/lib/xwiki
 #-#
 #-# The default is:
 # url.standard.multiwiki.notFoundBehavior=redirect_to_main_wiki
+
+#-# [Since 7.2M1]
+#-# Whether the "view" action is omitted in URLs (in order to have shorter URLs).
+#-# Note that this replaces the old xwiki.showviewaction property in the xwiki.cfg file.
+#-#
+#-# The default is:
+# url.standard.hideViewAction=false
 
 #-------------------------------------------------------------------------------------
 # Attachment
@@ -619,9 +609,9 @@ environment.permanentDirectory=/var/lib/xwiki
 #-------------------------------------------------------------------------------------
 
 #-# [Since 5.4.4]
-#-# Add a default suffix to the alias of a new wiki in the wiki creation wizard, only when the path mode is used
-#-# (see url.standard.multiwiki.isPathBased). If this value is empty, XWiki will try to compute it automatically from
-#-# request URL.
+#-# Add a default suffix to the alias of a new wiki in the wiki creation wizard, only when the path mode is not used
+#-# (i.e. domain-based, see url.standard.multiwiki.isPathBased). If this value is empty, XWiki will try to compute it
+#-# automatically from the request URL.
 #-#
 #-# eg: if wiki.alias.suffix is "xwiki.org" and the wiki name is "playground"
 #-#     then the computed alias will be: "playground.xwiki.org".
@@ -720,5 +710,59 @@ environment.permanentDirectory=/var/lib/xwiki
 #-# This is currently an experimental feature which is not yet ready for producton. Enabling it right now will cause performance issues.
 #-# Once the feature stabilizes, it will be enabled by default and the option to disabled it will be removed.
 # watchlist.realtime.enabled = false
+
+#-# [Since 8.1M2]
+#-# Controls if realtime notifications are triggered by remote events. Default value is false.
+#-# Enable if you don't have watchlist loaded on all instances in cluster.
+# watchlist.realtime.allowRemote = false
+
+#-------------------------------------------------------------------------------------
+# Debug
+#-------------------------------------------------------------------------------------
+
+#-# [Since 7.0RC1]
+#-# Indicate if web resources should be loaded minified by default.
+#-# It's enabled by default which can make js/css hard to read.
+# debug.minify=false
+
+#-------------------------------------------------------------------------------------
+# LESS CSS
+#-------------------------------------------------------------------------------------
+
+#-# [Since 7.4.2, 8.0M2]
+#-# The number of LESS compilations that can be performed simultaneously. Put a little number if your resources are
+#-# limited.
+#-#
+#-# The default is:
+# lesscss.maximumSimultaneousCompilations = 4
+
+#-# [Since 8.0RC1]
+#-# Generate sourcemaps inline in the CSS files.
+#-#
+#-# The default is:
+# lesscss.generateInlineSourceMaps = false
+
+#-------------------------------------------------------------------------------------
+# Edit
+#-------------------------------------------------------------------------------------
+
+#-# [Since 8.2RC1]
+#-# Indicate the default editor to use for a specific data type.
+#-# The editors are components so they are specified using their role hints.
+#-# Some data types can be edited in multiple ways, by different types of editors.
+#-# Thus you can also indicate the default editor to use from a specific category (editor type).
+#-#
+#-# The format is this:
+#-# edit.defaultEditor.<dataType>=<roleHintOrCategory>
+#-# edit.defaultEditor.<dataType>#<category>=<roleHintOrSubCategory>
+#-#
+#-# The default bindings are:
+# edit.defaultEditor.org.xwiki.rendering.syntax.SyntaxContent=text
+# edit.defaultEditor.org.xwiki.rendering.syntax.SyntaxContent#text=text
+# edit.defaultEditor.org.xwiki.rendering.block.XDOM=text
+# edit.defaultEditor.org.xwiki.rendering.block.XDOM#text=text
+edit.defaultEditor.org.xwiki.rendering.syntax.SyntaxContent#wysiwyg=ckeditor
+edit.defaultEditor.org.xwiki.rendering.block.XDOM#wysiwyg=ckeditor
+
 
 

--- a/files/xwiki.properties
+++ b/files/xwiki.properties
@@ -84,7 +84,7 @@
 #-# If neither the system property nor this configuration value here are set then the Servlet container's temporary
 #-# directory is used; This is absolutely not recommended since that directory could be wiped out at any time and you
 #-# should specify a value.
-environment.permanentDirectory=/var/local/xwiki/
+environment.permanentDirectory=/var/lib/xwiki/
 
 #-------------------------------------------------------------------------------------
 # Rendering
@@ -250,7 +250,7 @@ environment.permanentDirectory=/var/local/xwiki/
 #-# [Since 1.9M2]
 #-# If the openoffice server should be started / connected upon XE start.
 #-# Default value is false
-# openoffice.autoStart=false
+openoffice.autoStart=true
 
 #-# [Since 1.8RC3]
 #-# Path to openoffice installation (serverType:0 only).

--- a/quickRun.sh
+++ b/quickRun.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-XWIKI_PORT=8080
+XWIKI_PORT=1080
 echo "XWiki will be started at local port $XWIKI_PORT. Edit quickRun.sh to change it"
 echo "Building docker container. This will take some time at first run"
 docker build -t xwiki .
@@ -11,4 +11,4 @@ echo "Stopping data container"
 docker stop xwiki-data
 echo "Starting Container xwiki"
 echo "Visit http://localhost:$XWIKI_PORT after startup"
-docker run --volumes-from xwiki-data -p $XWIKI_PORT:8080 xwiki
+docker run -it --volumes-from xwiki-data -p $XWIKI_PORT:8080 xwiki

--- a/quickRun.sh
+++ b/quickRun.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+XWIKI_PORT=8080
+echo "XWiki will be started at local port $XWIKI_PORT. Edit quickRun.sh to change it"
+echo "Building docker container. This will take some time at first run"
+docker build -t xwiki .
+# The next two lines are necessary to authorize access to your data to the container
+# you will be asked for sudo access
+echo "Creating data container"
+docker run -it -d --name xwiki-data xwiki
+echo "Stopping data container"
+docker stop xwiki-data
+echo "Starting Container xwiki"
+echo "Visit http://localhost:$XWIKI_PORT after startup"
+docker run --volumes-from xwiki-data -p $XWIKI_PORT:8080 xwiki


### PR DESCRIPTION
Update Dockerfile with:

* Support for XWiki 8.4.1 and Java 8
* Added libreoffice server
* Added xinit to manage xwiki instance
* Added webapps/ROOT/index.html to redirect to XWiki page from root URL
* Persistence handled in a data container
* Change distributionId to xwiki-enterprise-docker to identify installs using this Dockerfile
* Added quickRun.sh for one click build and run

