### PR TITLE
Dockerfile optimisations (docker image size)

### DIFF
--- a/xwiki-mysql-tomcat/Dockerfile
+++ b/xwiki-mysql-tomcat/Dockerfile
@@ -36,9 +36,14 @@ RUN echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/so
   rm -rf /var/lib/apt/lists/*
 
 # Install XWiki as the ROOT webapp context in Tomcat
+# Create the Tomcat temporary directory
+# Configure the XWiki permanent directory
 RUN rm -rf /var/lib/tomcat8/webapps/* && \
+  mkdir -p /var/lib/tomcat8/temp && \
+  mkdir -p /var/lib/xwiki && \
   curl -L "http://download.forge.ow2.org/xwiki/xwiki-enterprise-web-${XWIKI_VERSION}.war" -o xwiki.war && \ 
   unzip -d /var/lib/tomcat8/webapps/ROOT xwiki.war && \
+  chown -R tomcat8:tomcat8 /var/lib/tomcat8 /var/lib/xwiki && \
   rm -f xwiki.war
 
 # Download the MySQL JDBC driver and install it in the XWiki webapp
@@ -52,23 +57,13 @@ RUN curl -L https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/share/tomcat8/bin/
 
-# Create the Tomcat temporary directory
-RUN mkdir -p /var/lib/tomcat8/temp
-
 # Setup the XWiki Hibernate configuration
 COPY xwiki/hibernate.cfg.xml /var/lib/tomcat8/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-
-# Configure the XWiki permanent directory
-RUN mkdir -p /var/lib/xwiki
 
 # Set a specific distribution id in XWiki for this docker packaging.
 RUN sed "s/<id>org.xwiki.enterprise:xwiki-enterprise-web/<id>org.xwiki.enterprise:xwiki-enterprise-docker/" \
     < /var/lib/tomcat8/webapps/ROOT/META-INF/extension.xed > /var/lib/tomcat8/webapps/ROOT/META-INF/extension2.xed && \
   mv /var/lib/tomcat8/webapps/ROOT/META-INF/extension2.xed /var/lib/tomcat8/webapps/ROOT/META-INF/extension.xed
-
-# Set ownership and permission to the tomcat8 user
-RUN chown -R tomcat8:tomcat8 /var/lib/xwiki
-RUN chown -R tomcat8:tomcat8 /var/lib/tomcat8
 
 # Add scripts required to make changes to XWiki configuration files at execution time
 COPY xwiki/xwiki-config-replace.sh /usr/local/bin/xwiki-config-replace.sh

--- a/xwiki-mysql-tomcat/Dockerfile
+++ b/xwiki-mysql-tomcat/Dockerfile
@@ -32,7 +32,7 @@ ENV XWIKI_VERSION=8.4.4 \
 RUN echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list && \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y --force-yes install sudo nano unzip curl openjdk-8-jdk tomcat8 libreoffice && \
+  apt-get --no-install-recommends -y --force-yes install sudo nano unzip curl openjdk-8-jdk tomcat8 libreoffice && \
   rm -rf /var/lib/apt/lists/*
 
 # Install XWiki as the ROOT webapp context in Tomcat

--- a/xwiki-mysql-tomcat/Dockerfile
+++ b/xwiki-mysql-tomcat/Dockerfile
@@ -32,7 +32,8 @@ ENV XWIKI_VERSION=8.4.4 \
 RUN echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list && \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y --force-yes install sudo nano unzip curl openjdk-8-jdk tomcat8 libreoffice
+  apt-get -y --force-yes install sudo nano unzip curl openjdk-8-jdk tomcat8 libreoffice && \
+  rm -rf /var/lib/apt/lists/*
 
 # Install XWiki as the ROOT webapp context in Tomcat
 RUN rm -rf /var/lib/tomcat8/webapps/* && \


### PR DESCRIPTION
- Clear apt to gain a few MB (50 MB)
- Use --no-install-recommends (200 MB)
- move chown -R tomcat8:tomcat8 /var/lib/tomcat8 (250 MB)

For --no-install-recommends, I'd like to point out that **recommended but not mandatory packages are now skipped**, so this might require some testing to validate. 
As far as I could see, the xwiki instance built with this code is working perfectly, but there might be some hidden effects I could not detect. Also, I have no idea why you need libreoffice in the first place so I didn't know what to test ...