### PR TITLE
Improvement : XDOCKER-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,15 @@ You should adapt the command line to use the passwords that you wish for the MyS
 Then run XWiki in another container by issuing the following command:
 
 ```console
-docker run -d --net=xwiki-nw --name xwiki -p 8080:8080 -v /my/own/xwiki:/usr/local/xwiki -e MYSQL_USER=xwiki -e MYSQL_PASSWORD=xwiki -e MYSQL_DATABASE=xwiki -e MYSQL_CONTAINER_NAME=mysql-xwiki xwiki:mysql-tomcat
+docker run --net=xwiki-nw --name xwiki -p 8080:8080 -v /my/own/xwiki:/usr/local/xwiki -e MYSQL_USER=xwiki -e MYSQL_PASSWORD=xwiki -e MYSQL_DATABASE=xwiki -e DB_CONTAINER_NAME=mysql-xwiki xwiki:mysql-tomcat
 ```
 
-Be careful to use the same MySQL username, password and database names that you've used on the first command to start the MySQL container. Also, please don't forget to add a '-e MYSQL_CONTAINER_NAME=' env variable with the name of the previously created MySQL container so that tomcat knows where its database is.
+Be careful to use the same MySQL username, password and database names that you've used on the first command to start the MySQL container. Also, please don't forget to add a '-e DB_CONTAINER_NAME=' env variable with the name of the previously created MySQL container so that XWiki knows where its database is.
+
+At this point, XWiki should start in interactive mode. Should you wish to run it in "detached mode", just add a "-d" flag in the previous command.
+```console
+docker run -d --net=xwiki-nw ...
+```
 
 ### Using docker-compose
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,16 @@ You need to run 2 containers:
 
 ### Using docker run
 
-Start by running a MySQL container and ensure you configure MySQL to use UTF8. The command below will also configure the MySQL container to save its data on your localhost in a `/my/own/mysql` directory: 
+Start by creating a dedicated docker network
 
 ```console
-docker run --name mysql-xwiki -v /my/own/mysql:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=xwiki -e MYSQL_USER=xwiki -e MYSQL_PASSWORD=xwiki -e MYSQL_DATABASE=xwiki -d mysql:5.7 --character-set-server=utf8 --collation-server=utf8_bin --explicit-defaults-for-timestamp=1 
+docker network create -d bridge xwiki-nw 
+```
+
+Then run a MySQL container and ensure you configure MySQL to use UTF8. The command below will also configure the MySQL container to save its data on your localhost in a `/my/own/mysql` directory: 
+
+```console
+docker run --net=xwiki-nw --name mysql-xwiki -v /my/own/mysql:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=xwiki -e MYSQL_USER=xwiki -e MYSQL_PASSWORD=xwiki -e MYSQL_DATABASE=xwiki -d mysql:5.7 --character-set-server=utf8 --collation-server=utf8_bin --explicit-defaults-for-timestamp=1 
 ```
 
 You should adapt the command line to use the passwords that you wish for the MySQL root password and for the xwiki user password.
@@ -44,10 +50,10 @@ You should adapt the command line to use the passwords that you wish for the MyS
 Then run XWiki in another container by issuing the following command:
 
 ```console
-docker run --name xwiki -p 8080:8080 -v /my/own/xwiki:/usr/local/xwiki -e MYSQL_USER=xwiki -e MYSQL_PASSWORD=xwiki -e MYSQL_DATABASE=xwiki --link mysql-xwiki:db xwiki:mysql-tomcat
+docker run -d --net=xwiki-nw --name xwiki -p 8080:8080 -v /my/own/xwiki:/usr/local/xwiki -e MYSQL_USER=xwiki -e MYSQL_PASSWORD=xwiki -e MYSQL_DATABASE=xwiki -e MYSQL_CONTAINER_NAME=mysql-xwiki xwiki:mysql-tomcat
 ```
 
-Be careful to use the same MySQL username, password and database names that you've used on the first command to start the MySQL container.
+Be careful to use the same MySQL username, password and database names that you've used on the first command to start the MySQL container. Also, please don't forget to add a '-e MYSQL_CONTAINER_NAME=' env variable with the name of the previously created MySQL container so that tomcat knows where its database is.
 
 ### Using docker-compose
 

--- a/xwiki-mysql-tomcat/docker-compose-using.yml
+++ b/xwiki-mysql-tomcat/docker-compose-using.yml
@@ -18,11 +18,14 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 # ---------------------------------------------------------------------------
 version: '2'
+networks:
+  xwiki-nw:
+    driver: bridge
 services:
-  # The container that runs XWiki + Tomcat
   web:
     # Use an already built XWiki image from DockerHub.
     image: "xwiki:mysql-tomcat"
+    container_name: xwiki
     depends_on:
       - db
     ports:
@@ -31,13 +34,17 @@ services:
     environment:
       - MYSQL_USER=xwiki
       - MYSQL_PASSWORD=xwiki
+      - DB_CONTAINER_NAME=xwiki-mysql
     # Provide a name instead of an auto-generated id for the xwiki permanent directory configured in the Dockerfile,
     # to make it simpler to identify in 'docker volume ls'.
     volumes:
       - xwiki-data:/usr/local/xwiki
+    networks:
+      - xwiki-nw
   # The container that runs MySQL
   db:
     image: "mysql:5.7"
+    container_name: xwiki-mysql
     # - We provide a xwiki.cnf file in order to configure the mysql db to support UTF8 and be case-insensitive
     # We have to do it here since we use an existing image and that's how this image allows customizations.
     # See https://hub.docker.com/_/mysql/ for more details.
@@ -53,6 +60,8 @@ services:
       - MYSQL_USER=xwiki
       - MYSQL_PASSWORD=xwiki
       - MYSQL_DATABASE=xwiki
+    networks:
+      - xwiki-nw
 volumes:
   mysql-data: {}
   xwiki-data: {}

--- a/xwiki-mysql-tomcat/docker-compose-using.yml
+++ b/xwiki-mysql-tomcat/docker-compose-using.yml
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------------
 version: '2'
 networks:
-  xwiki-nw:
+  bridge:
     driver: bridge
 services:
   web:
@@ -40,7 +40,7 @@ services:
     volumes:
       - xwiki-data:/usr/local/xwiki
     networks:
-      - xwiki-nw
+      - bridge
   # The container that runs MySQL
   db:
     image: "mysql:5.7"
@@ -61,7 +61,7 @@ services:
       - MYSQL_PASSWORD=xwiki
       - MYSQL_DATABASE=xwiki
     networks:
-      - xwiki-nw
+      - bridge
 volumes:
   mysql-data: {}
   xwiki-data: {}

--- a/xwiki-mysql-tomcat/docker-compose.yml
+++ b/xwiki-mysql-tomcat/docker-compose.yml
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------------
 version: '2'
 networks:
-  xwiki-nw:
+  bridge:
     driver: bridge
 services:
   # The container that runs XWiki + Tomcat
@@ -44,7 +44,7 @@ services:
     volumes:
       - xwiki-data:/usr/local/xwiki
     networks:
-      - xwiki-nw
+      - bridge
   # The container that runs MySQL
   db:
     image: "mysql:5.7"
@@ -66,7 +66,7 @@ services:
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=${MYSQL_DATABASE}
     networks:
-      - xwiki-nw
+      - bridge
 volumes:
   mysql-data: {}
   xwiki-data: {}

--- a/xwiki-mysql-tomcat/docker-compose.yml
+++ b/xwiki-mysql-tomcat/docker-compose.yml
@@ -18,29 +18,37 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 # ---------------------------------------------------------------------------
 version: '2'
+networks:
+  xwiki-nw:
+    driver: bridge
 services:
   # The container that runs XWiki + Tomcat
   web:
     build: .
+    container_name: xwiki
     depends_on:
       - db
     ports:
       - "8080:8080"
     # Default values defined in .env file.
-    # The MYSQL_USER/MYSQL_PASSWORD/MYSQL_DATABASE variables are used in the hibernate.cfg.xml file.
+    # The MYSQL_USER/MYSQL_PASSWORD/MYSQL_DATABASE/DB_CONTAINER_NAME variables are used in the hibernate.cfg.xml file.
     environment:
       - XWIKI_VERSION=${XWIKI_VERSION}
       - MYSQL_DRIVER_VERSION=${MYSQL_DRIVER_VERSION}
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - DB_CONTAINER_NAME=xwiki-mysql
     # Provide a name instead of an auto-generated id for xwiki data (the permanent directory in included in it)
     # configured in the Dockerfile, to make it simpler to identify in 'docker volume ls'.
     volumes:
       - xwiki-data:/usr/local/xwiki
+    networks:
+      - xwiki-nw
   # The container that runs MySQL
   db:
     image: "mysql:5.7"
+    container_name: xwiki-mysql
     # - We provide a xwiki.cnf file in order to configure the mysql db to support UTF8 and be case-insensitive
     # We have to do it here since we use an existing image and that's how this image allows customizations.
     # See https://hub.docker.com/_/mysql/ for more details.
@@ -57,6 +65,8 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=${MYSQL_DATABASE}
+    networks:
+      - xwiki-nw
 volumes:
   mysql-data: {}
   xwiki-data: {}

--- a/xwiki-mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/xwiki-mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -49,7 +49,7 @@ function configure() {
   echo 'Configuring XWiki...'
   sed -i "s/replacemysqluser/${MYSQL_USER:-xwiki}/g" /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
   sed -i "s/replacemysqlpassword/${MYSQL_PASSWORD:-xwiki}/g" /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  sed -i "s/replacemysqlcontainername/${MYSQL_CONTAINER_NAME:-db}/g" /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  sed -i "s/replacemysqlcontainername/${DB_CONTAINER_NAME:-db}/g" /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
   sed -i "s/replacemysqldatabase/${MYSQL_DATABASE:-xwiki}/g" /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
 
   echo '  Using filesystem-based attachments...'

--- a/xwiki-mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/xwiki-mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -49,6 +49,8 @@ function configure() {
   echo 'Configuring XWiki...'
   sed -i "s/replacemysqluser/${MYSQL_USER:-xwiki}/g" /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
   sed -i "s/replacemysqlpassword/${MYSQL_PASSWORD:-xwiki}/g" /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  sed -i "s/replacemysqlcontainername/${MYSQL_CONTAINER_NAME:-db}/g" /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  sed -i "s/replacemysqldatabase/${MYSQL_DATABASE:-xwiki}/g" /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
 
   echo '  Using filesystem-based attachments...'
   xwiki_set_cfg 'xwiki.store.attachment.hint' 'file'

--- a/xwiki-mysql-tomcat/xwiki/hibernate.cfg.xml
+++ b/xwiki-mysql-tomcat/xwiki/hibernate.cfg.xml
@@ -84,7 +84,7 @@
            - if you want the main wiki database to be different than "xwiki"
              you will also have to set the property xwiki.db in xwiki.cfg file
     -->
-    <property name="connection.url">jdbc:mysql://db/${MYSQL_DATABASE:-xwiki}?useSSL=false</property>
+    <property name="connection.url">jdbc:mysql://replacemysqlcontainername/replacemysqldatabase?useSSL=false</property>
     <property name="connection.username">replacemysqluser</property>
     <property name="connection.password">replacemysqlpassword</property>
     <property name="connection.driver_class">com.mysql.jdbc.Driver</property>


### PR DESCRIPTION
From http://jira.xwiki.org/browse/XDOCKER-11

Changed a few lines to remove deprecated docker link usage and allow docker network

Checked that everything works running these commands
```
docker network create -d bridge xwiki-nw
docker run --net=xwiki-nw --name mysql-xwiki -v /my/own/mysql:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=aaaaa -e MYSQL_USER=xwikicustom -e MYSQL_PASSWORD=xwikicustom -e MYSQL_DATABASE=xwiki -d mysql:5.7 --character-set-server=utf8 --collation-server=utf8_bin --explicit-defaults-for-timestamp=1
docker run --net=xwiki-nw -d --name xwiki -p 8080:8080 -v /my/own/xwiki:/usr/local/xwiki -e MYSQL_USER=xwikicustom -e MYSQL_PASSWORD=xwikicustom -e MYSQL_DATABASE=xwiki -e MYSQL_CONTAINER_NAME=mysql-xwiki xwiki:mysql-tomcat
```

Also, docker compose is unaffected by this commit (still works). Checked with :
```
docker-compose up -d
```

Updated README.md to reflect this change