### PR TITLE
XDOCKER-38: Adds system properties to setenv.sh to allow '/' and '\' in wiki pages

### DIFF
--- a/8/mysql-tomcat/tomcat/setenv.sh
+++ b/8/mysql-tomcat/tomcat/setenv.sh
@@ -1,1 +1,1 @@
-export CATALINA_OPTS="-Xmx1024m"
+export CATALINA_OPTS="-Xmx1024m -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Dorg.apache.catalina.connector.CoyoteAdapter.ALLOW_BACKSLASH=true"

--- a/8/postgres-tomcat/tomcat/setenv.sh
+++ b/8/postgres-tomcat/tomcat/setenv.sh
@@ -1,1 +1,1 @@
-export CATALINA_OPTS="-Xmx1024m"
+export CATALINA_OPTS="-Xmx1024m -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Dorg.apache.catalina.connector.CoyoteAdapter.ALLOW_BACKSLASH=true"

--- a/9/mysql-tomcat/tomcat/setenv.sh
+++ b/9/mysql-tomcat/tomcat/setenv.sh
@@ -1,1 +1,1 @@
-export CATALINA_OPTS="-Xmx1024m"
+export CATALINA_OPTS="-Xmx1024m -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Dorg.apache.catalina.connector.CoyoteAdapter.ALLOW_BACKSLASH=true"

--- a/9/postgres-tomcat/tomcat/setenv.sh
+++ b/9/postgres-tomcat/tomcat/setenv.sh
@@ -1,1 +1,1 @@
-export CATALINA_OPTS="-Xmx1024m"
+export CATALINA_OPTS="-Xmx1024m -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Dorg.apache.catalina.connector.CoyoteAdapter.ALLOW_BACKSLASH=true"

--- a/template/tomcat/setenv.sh
+++ b/template/tomcat/setenv.sh
@@ -1,1 +1,1 @@
-export CATALINA_OPTS="-Xmx1024m"
+export CATALINA_OPTS="-Xmx1024m -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Dorg.apache.catalina.connector.CoyoteAdapter.ALLOW_BACKSLASH=true"


### PR DESCRIPTION
Fixes https://jira.xwiki.org/browse/XDOCKER-38
