### PR TITLE
improved docker-entrypoint.sh by adding compatibility for docker secrets

### DIFF
--- a/10/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/10/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -52,6 +52,28 @@ function xwiki_set_properties() {
   xwiki_replace /usr/local/tomcat/webapps/ROOT/WEB-INF/xwiki.properties "$1" "$2"
 }
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+    echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+    exit 1
+  fi
+  local val="$def"
+  if [ "${!var:-}" ]; then
+    val="${!var}"
+  elif [ "${!fileVar:-}" ]; then
+    val="$(< "${!fileVar}")"
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
+
 # Allows to use sed but with user input which can contain special sed characters such as \, / or &.
 # $1 - the text to search for
 # $2 - the replacement text
@@ -84,10 +106,18 @@ function restoreConfigurationFile() {
 
 function configure() {
   echo 'Configuring XWiki...'
-  safesed "replaceuser" ${DB_USER:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacepassword" ${DB_PASSWORD:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacecontainer" ${DB_HOST:-db} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacedatabase" ${DB_DATABASE:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+
+  echo 'Setting environment variables'
+  file_env 'DB_USER' 'xwiki'
+  file_env 'DB_PASSWORD' 'xwiki'
+  file_env 'DB_HOST' 'db'
+  file_env 'DB_DATABASE' 'xwiki'
+
+  echo 'Replacing environment variables in files'
+  safesed "replaceuser" $DB_USER /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacepassword" $DB_PASSWORD /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacecontainer" $DB_HOST /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacedatabase" $DB_DATABASE /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
 
   echo '  Using filesystem-based attachments...'
   xwiki_set_cfg 'xwiki.store.attachment.hint' 'file'

--- a/10/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/10/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -52,6 +52,28 @@ function xwiki_set_properties() {
   xwiki_replace /usr/local/tomcat/webapps/ROOT/WEB-INF/xwiki.properties "$1" "$2"
 }
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+    echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+    exit 1
+  fi
+  local val="$def"
+  if [ "${!var:-}" ]; then
+    val="${!var}"
+  elif [ "${!fileVar:-}" ]; then
+    val="$(< "${!fileVar}")"
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
+
 # Allows to use sed but with user input which can contain special sed characters such as \, / or &.
 # $1 - the text to search for
 # $2 - the replacement text
@@ -84,10 +106,18 @@ function restoreConfigurationFile() {
 
 function configure() {
   echo 'Configuring XWiki...'
-  safesed "replaceuser" ${DB_USER:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacepassword" ${DB_PASSWORD:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacecontainer" ${DB_HOST:-db} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacedatabase" ${DB_DATABASE:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+
+  echo 'Setting environment variables'
+  file_env 'DB_USER' 'xwiki'
+  file_env 'DB_PASSWORD' 'xwiki'
+  file_env 'DB_HOST' 'db'
+  file_env 'DB_DATABASE' 'xwiki'
+
+  echo 'Replacing environment variables in files'
+  safesed "replaceuser" $DB_USER /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacepassword" $DB_PASSWORD /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacecontainer" $DB_HOST /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacedatabase" $DB_DATABASE /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
 
   echo '  Using filesystem-based attachments...'
   xwiki_set_cfg 'xwiki.store.attachment.hint' 'file'

--- a/9/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/9/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -52,6 +52,28 @@ function xwiki_set_properties() {
   xwiki_replace /usr/local/tomcat/webapps/ROOT/WEB-INF/xwiki.properties "$1" "$2"
 }
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+    echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+    exit 1
+  fi
+  local val="$def"
+  if [ "${!var:-}" ]; then
+    val="${!var}"
+  elif [ "${!fileVar:-}" ]; then
+    val="$(< "${!fileVar}")"
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
+
 # Allows to use sed but with user input which can contain special sed characters such as \, / or &.
 # $1 - the text to search for
 # $2 - the replacement text
@@ -84,10 +106,18 @@ function restoreConfigurationFile() {
 
 function configure() {
   echo 'Configuring XWiki...'
-  safesed "replaceuser" ${DB_USER:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacepassword" ${DB_PASSWORD:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacecontainer" ${DB_HOST:-db} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacedatabase" ${DB_DATABASE:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+
+  echo 'Setting environment variables'
+  file_env 'DB_USER' 'xwiki'
+  file_env 'DB_PASSWORD' 'xwiki'
+  file_env 'DB_HOST' 'db'
+  file_env 'DB_DATABASE' 'xwiki'
+
+  echo 'Replacing environment variables in files'
+  safesed "replaceuser" $DB_USER /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacepassword" $DB_PASSWORD /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacecontainer" $DB_HOST /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacedatabase" $DB_DATABASE /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
 
   echo '  Using filesystem-based attachments...'
   xwiki_set_cfg 'xwiki.store.attachment.hint' 'file'

--- a/9/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/9/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -52,6 +52,28 @@ function xwiki_set_properties() {
   xwiki_replace /usr/local/tomcat/webapps/ROOT/WEB-INF/xwiki.properties "$1" "$2"
 }
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+    echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+    exit 1
+  fi
+  local val="$def"
+  if [ "${!var:-}" ]; then
+    val="${!var}"
+  elif [ "${!fileVar:-}" ]; then
+    val="$(< "${!fileVar}")"
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
+
 # Allows to use sed but with user input which can contain special sed characters such as \, / or &.
 # $1 - the text to search for
 # $2 - the replacement text
@@ -84,10 +106,18 @@ function restoreConfigurationFile() {
 
 function configure() {
   echo 'Configuring XWiki...'
-  safesed "replaceuser" ${DB_USER:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacepassword" ${DB_PASSWORD:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacecontainer" ${DB_HOST:-db} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
-  safesed "replacedatabase" ${DB_DATABASE:-xwiki} /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+
+  echo 'Setting environment variables'
+  file_env 'DB_USER' 'xwiki'
+  file_env 'DB_PASSWORD' 'xwiki'
+  file_env 'DB_HOST' 'db'
+  file_env 'DB_DATABASE' 'xwiki'
+
+  echo 'Replacing environment variables in files'
+  safesed "replaceuser" $DB_USER /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacepassword" $DB_PASSWORD /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacecontainer" $DB_HOST /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
+  safesed "replacedatabase" $DB_DATABASE /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cfg.xml
 
   echo '  Using filesystem-based attachments...'
   xwiki_set_cfg 'xwiki.store.attachment.hint' 'file'

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ In order to support [Docker secrets](https://docs.docker.com/engine/swarm/secret
 - `DB_USER_FILE`: The location, inside the container, of a file containing the value for `DB_USER`
 - `DB_PASSWORD_FILE`: The location, inside the container, of a file containing the value for `DB_PASSWORD`
 - `DB_DATABASE_FILE`: The location, inside the container, of a file containing the value for `DB_DATABASE`
-- `DB_HOST_FILE`: The location, inside the container, of a file containing the value for `DB_HOST_FILE`
+- `DB_HOST_FILE`: The location, inside the container, of a file containing the value for `DB_HOST`
 
 *Note:* For each configuration value, the normal environment variable and \_FILE environment variable are mutually exclusive. Providing values for both variables will result in an error.
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,138 @@ volumes:
   xwiki-data: {}
 ```
 
+### Using Docker Swarm
+
+Here are some examples of using this image with Docker Swarm. These examples leverage additional features of Docker Swarm such as Docker secrets, and Docker configs. As such, these examples require Docker to be in swarm mode.
+
+You can read more about these features and Docker swarm mode here:
+- [Docker swarm mode](https://docs.docker.com/engine/swarm/)
+- [Creating Docker secrets](https://docs.docker.com/engine/reference/commandline/secret_create/)
+- [Creating Docker configs](https://docs.docker.com/engine/reference/commandline/config_create/)
+
+#### MySQL Example
+
+This example presupposes the existence of the Docker secrets `xwiki-db-username`, `xwiki-db-password` and `xwiki-db-root-password`, and the Docker config `xwiki-mysql-config`.
+
+You can create these secrets and configs with the following:
+- `echo ${MY_XWIKI_USER:-xwiki} | docker secret create xwiki-db-username -`
+- `echo $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1) | docker secret create xwiki-db-password -`
+- `echo $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1) | docker secret create xwiki-db-root-password -`
+- `docker config create xwiki-mysql-config /path/to/mysql/xwiki.cnf`
+
+To deploy this example, save the following YAML as _xwiki-stack.yaml_ then run:
+- `docker stack deploy -c xwiki-stack.yaml xwiki`
+
+```yaml
+version: '3.3'
+services:
+  web:
+    image: "xwiki:mysql-tomcat"
+    ports:
+      - "8080:8080"
+    environment:
+      - DB_USER_FILE=/run/secrets/xwiki-db-username
+      - DB_PASSWORD_FILE=/run/secrets/xwiki-db-password
+      - DB_DATABASE=xwiki
+      - DB_HOST=db
+    volumes:
+      - xwiki-data:/usr/local/xwiki
+    secrets:
+      - xwiki-db-username
+      - xwiki-db-password
+  db:
+    image: "mysql:5.7"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=/run/secrets/xwiki-db-root-password
+      - MYSQL_USER_FILE=/run/secrets/xwiki-db-username
+      - MYSQL_PASSWORD_FILE=/run/secrets/xwiki-db-password
+      - MYSQL_DATABASE=xwiki
+    secrets:
+      - xwiki-db-username
+      - xwiki-db-password
+      - xwiki-db-root-password
+    configs: 
+      - source: mysql-config
+        target: /etc/mysql/conf.d/xwiki.cnf
+volumes:
+  mysql-data:
+  xwiki-data:
+secrets:
+  xwiki-db-username:
+    external:
+      name: xwiki-db-username
+  xwiki-db-password:
+    external:
+      name: xwiki-db-password
+  xwiki-db-root-password:
+    external:
+      name: xwiki-db-root-password
+configs:
+  mysql-config:
+    external:
+      name: xwiki-mysql-config
+```
+
+#### PostgreSQL Example
+
+This example presupposes the existence of the Docker secrets `xwiki-db-username`, `xwiki-db-password`, and `xwiki-db-root-password`.
+
+You can create these secrets with the following:
+- `echo ${MY_XWIKI_USER:-xwiki} | docker secret create xwiki-db-username -`
+- `echo $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1) | docker secret create xwiki-db-password -`
+- `echo $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1) | docker secret create xwiki-db-root-password -`
+
+To deploy this example, save the following YAML as _xwiki-stack.yaml_ then run:
+- `docker stack deploy -c xwiki-stack.yaml xwiki`
+
+```yaml
+version: '3.3'
+services:
+  web:
+    image: "xwiki:mysql-postgres"
+    ports:
+      - "8080:8080"
+    environment:
+      - DB_USER_FILE=/run/secrets/xwiki-db-username
+      - DB_PASSWORD_FILE=/run/secrets/xwiki-db-password
+      - DB_DATABASE=xwiki
+      - DB_HOST=db
+    volumes:
+      - xwiki-data:/usr/local/xwiki
+    secrets:
+      - xwiki-db-username
+      - xwiki-db-password
+  db:
+    image: "postgres:9.5"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_ROOT_PASSWORD_FILE=/run/secrets/xwiki-db-root-password
+      - POSTGRES_USER_FILE=/run/secrets/xwiki-db-username
+      - POSTGRES_PASSWORD_FILE=/run/secrets/xwiki-db-password
+      - POSTGRES_DB=xwiki
+    secrets:
+      - xwiki-db-username
+      - xwiki-db-password
+      - xwiki-db-root-password
+volumes:
+  postgres-data:
+  xwiki-data:
+secrets:
+  xwiki-db-username:
+    external:
+      name: xwiki-db-username
+  xwiki-db-password:
+    external:
+      name: xwiki-db-password
+  xwiki-db-root-password:
+    external:
+      name: xwiki-db-root-password
+```
+
+
 ## Building
 
 This allows you to rebuild the XWiki docker image locally. Here are the steps:
@@ -230,6 +362,16 @@ The first time you create a container out of the xwiki image, a shell script (`/
 -	`DB_PASSWORD`: The user password used by XWiki to read/write to the DB.
 -	`DB_DATABASE`: The name of the XWiki database to use/create.
 -	`DB_HOST`: The name of the host (or docker container) containing the database. Default is "db".
+
+In order to support [Docker secrets](https://docs.docker.com/engine/swarm/secrets/), the configuration values can also be given to the container as files containing that value.
+
+- `DB_USER_FILE`: The location, inside the container, of a file containing the value for `DB_USER`
+- `DB_PASSWORD_FILE`: The location, inside the container, of a file containing the value for `DB_PASSWORD`
+- `DB_DATABASE_FILE`: The location, inside the container, of a file containing the value for `DB_DATABASE`
+- `DB_HOST_FILE`: The location, inside the container, of a file containing the value for `DB_HOST_FILE`
+
+*Note:* For each configuration value, the normal environment variable and \_FILE environment variable are mutually exclusive. Providing values for both variables will result in an error.
+
 
 The main XWiki configuration files (`xwiki.cfg`, `xwiki.properties` and `hibernate.cfg.xml`) are available in the mapped local directory for the permanent directory on your host.
 


### PR DESCRIPTION
Based on [docker documentation](https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images) for adding support for docker secrets, and the methodology from 
 the [wordpress entrypoint](https://github.com/docker-library/wordpress/blob/master/docker-entrypoint.sh).

I've included an example which leverages the new functionality in _examples/docker-secrets_

To test:
1. If docker is not already in swarm mode, `docker swarm init`
1. In the project root, `cd 10/mysql-tomcat`
1. `docker build --no-cache -t xwiki:mysql-tomcat-swarm .` the image is tagged differently to avoid any conflict with the official image
1. In the project root, `cd examples/docker-secrets`
1. `./docker-secrets-example-init.sh` initializes docker secrets, volumes, and config, then deploys the stack
1. Await services startup, `docker service logs -f xwiki-secrets-example_web`
1. Check that the secret values have been substituted `cat /var/lib/docker/volumes/xwiki-web-data/_data/data/hibernate.cfg.xml`