### PR TITLE
XDOCKER-75: external solr container fails to start because unzip does…

### DIFF
--- a/contrib/solr/solr-init.sh
+++ b/contrib/solr/solr-init.sh
@@ -28,12 +28,12 @@ mkdir -p $location
 
 # Add the XWiki Solr plugin
 plugin=$(unzip -Z1 $jar | grep lib.*jar)
-unzip $jar \
+unzip -o $jar \
 	$plugin \
 	-d $location
 
 # Add the XWiki core
 core='xwiki/*'
-unzip $jar \
+unzip -o $jar \
 	$core \
 	-d $location


### PR DESCRIPTION
… not overwrite existing files.

See https://jira.xwiki.org/browse/XDOCKER-75