### PR TITLE
XDOCKER-87: create image for external SOLR, add example compose file

### DIFF
--- a/contrib/solr/Dockerfile
+++ b/contrib/solr/Dockerfile
@@ -1,0 +1,17 @@
+# ARG used in FROM must come first
+ARG SOLR_VERSION=7.5.0
+
+FROM busybox as buildenv
+
+# ARG for build must come after the FROM statement
+ARG XWIKI_VERSION=10.9
+ARG XWIKI_URL_PREFIX="https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-data/${XWIKI_VERSION}"
+
+WORKDIR /var/xwiki-solr-temp/
+
+COPY ./solr-init.sh .
+RUN wget "${XWIKI_URL_PREFIX}/xwiki-platform-search-solr-server-data-${XWIKI_VERSION}.jar"
+
+FROM solr:${SOLR_VERSION}
+
+COPY --from=buildenv /var/xwiki-solr-temp/ /docker-entrypoint-initdb.d/

--- a/docker-compose-postgres-index.yml
+++ b/docker-compose-postgres-index.yml
@@ -1,0 +1,76 @@
+# ---------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+# ---------------------------------------------------------------------------
+version: '2'
+networks:
+  bridge:
+    driver: bridge
+services:
+  web:
+    # Use an already built XWiki image from DockerHub.
+    image: "xwiki:10.9-postgres-tomcat"
+    container_name: xwiki-postgres-tomcat-web
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+    # The DB_USER/DB_PASSWORD/DB_HOST variables are used in the hibernate.cfg.xml file.
+    environment:
+      - DB_USER=xwiki
+      - DB_PASSWORD=xwiki
+      - DB_DATABASE=xwiki
+      - DB_HOST=xwiki-postgres-db
+      - INDEX_HOST=index
+    # Provide a name instead of an auto-generated id for the xwiki permanent directory configured in the Dockerfile,
+    # to make it simpler to identify in 'docker volume ls'.
+    volumes:
+      - xwiki-data:/usr/local/xwiki
+    networks:
+      - bridge
+  # The container that runs PostgreSQL
+  db:
+    image: "postgres:9.6"
+    container_name: xwiki-postgres-db
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_ROOT_PASSWORD=xwiki
+      - POSTGRES_PASSWORD=xwiki
+      - POSTGRES_USER=xwiki
+      - POSTGRES_DB=xwiki
+      - POSTGRES_INITDB_ARGS="--encoding=UTF8"
+    networks:
+      - bridge
+  # The container running Apache SOLR as search index for xwiki
+  index:
+    image: "xwiki/solr:10.9"
+    container_name: xwiki-solr-index
+    build:
+      context: ./contrib/solr
+      args:
+        - SOLR_VERSION=7.5.0
+        - XWIKI_VERSION=10.9
+    volumes:
+      - solr-data:/opt/solr/server/solr
+    networks:
+      - bridge
+volumes:
+  postgres-data: {}
+  xwiki-data: {}
+  solr-data: {}


### PR DESCRIPTION
https://jira.xwiki.org/browse/XDOCKER-87

- [X]  Add dockerfile for /contrib/solr/ . This custom image downloads the correct `xwiki-platform-search-solr-server-data.jar` , the image uses the latest Apache SOLR image as base

- [X] Add demo compose file `docker-compose-postgres-index.yml`, it uses the already existing environment variable `INDEX_HOST` of the `web` container. Since it must have the xwiki version, `10.9` has been used for the demo.